### PR TITLE
Switch badges for Rockets - Conditional components

### DIFF
--- a/src/components/RocketItem.jsx
+++ b/src/components/RocketItem.jsx
@@ -5,18 +5,33 @@ import { reserveRocket } from '../redux/rockets/rocketsSlice';
 import '../styles/rockets.css';
 
 const RocketItem = ({
-  id, name, Image, description,
+  id, name, Image, description, reserved,
 }) => {
   const dispatch = useDispatch();
+  if (!reserved) {
+    return (
+      <div className="rocketItemCont">
+        <img src={Image[0]} alt="" />
+        <section id={id} className="rocket_details">
+          <h2>{name }</h2>
+          <p>
+            {description}
+          </p>
+          <button type="button" value="Reserve Rocket" onClick={() => (dispatch(reserveRocket(id)))}>Reserve Rocket</button>
+        </section>
+      </div>
+    );
+  }
   return (
     <div className="rocketItemCont">
       <img src={Image[0]} alt="" />
       <section id={id} className="rocket_details">
         <h2>{name }</h2>
         <p>
+          <p className="reservedTag">Reserved</p>
           {description}
         </p>
-        <button type="button" value="Reserve Rocket" onClick={() => (dispatch(reserveRocket(id)))}>Reserve Rocket</button>
+        <button type="button" value="Reserve Rocket" onClick={() => (dispatch(reserveRocket(id)))}>Cancel Reservation</button>
       </section>
     </div>
   );
@@ -26,5 +41,6 @@ RocketItem.propTypes = { id: PropTypes.string.isRequired };
 RocketItem.propTypes = { name: PropTypes.string.isRequired };
 RocketItem.propTypes = { Image: PropTypes.string.isRequired };
 RocketItem.propTypes = { description: PropTypes.string.isRequired };
+RocketItem.propTypes = { reserved: PropTypes.bool.isRequired };
 
 export default RocketItem;

--- a/src/components/RocketPage.jsx
+++ b/src/components/RocketPage.jsx
@@ -26,6 +26,7 @@ const RocketPage = () => {
           name={item.name}
           description={item.description}
           Image={item.flickr_images}
+          reserved={item.reserved}
         />
       ))}
     </div>

--- a/src/redux/rockets/rocketsSlice.js
+++ b/src/redux/rockets/rocketsSlice.js
@@ -43,6 +43,7 @@ const rocketsSlice = createSlice({
           type: item.rocket_type,
           description: item.description,
           flickr_images: item.flickr_images,
+          reserved: false,
         }));
         state.rocketItems = rocketsData;
       })


### PR DESCRIPTION
Rockets that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design)

Use the React conditional rendering syntax:
```javascript
{rocket.reserved && ( 
    // render Cancel Rocket button
)}
```